### PR TITLE
Stick with manual parsing over native (for now)

### DIFF
--- a/src/fromJSON.ts
+++ b/src/fromJSON.ts
@@ -6,7 +6,7 @@ import { UserRegistrationInfo } from './SDK'
 export const parseRequestOptions = (json: CredentialRequestOptionsJSON): CredentialRequestOptions => {
   let getOptions: CredentialRequestOptions = {}
   getOptions.mediation = json.mediation
-  // TODO: restore parseRequestOptionsFromJSON (see #xxx)
+  // TODO: restore parseRequestOptionsFromJSON (see #16+#17)
   // Manually remap buffersources
   getOptions.publicKey = {
     ...json.publicKey,
@@ -29,7 +29,7 @@ export const parseCreateOptions = (user: UserRegistrationInfo, json: CredentialC
 
   let createOptions: CredentialCreationOptions = {}
 
-  // TODO: restore parseCreationOptionsFromJSON (see #xxx)
+  // TODO: restore parseCreationOptionsFromJSON (see #16+#17)
   createOptions.publicKey = {
     ...json.publicKey,
     challenge: toAB(json.publicKey.challenge),

--- a/src/toJSON.ts
+++ b/src/toJSON.ts
@@ -4,7 +4,7 @@ import {
 } from './utils'
 
 export const registrationResponseToJSON = (credential: PublicKeyCredential): RegistrationResponseJSON => {
-  // TODO: if credential.toJSON exists, prefer it?
+  // TODO: restore credential.toJSON if it exists (see #16+#17)
   const response = credential.response as AuthenticatorAttestationResponse
   return {
     id: credential.id,
@@ -24,7 +24,7 @@ export const registrationResponseToJSON = (credential: PublicKeyCredential): Reg
  }
 
 export const authenticationResponseToJSON = (credential: PublicKeyCredential): AuthenticationResponseJSON => {
-  // TODO: if credential.toJSON exists, prefer it?
+  // TODO: restore credential.toJSON if it exists (see #16+#17)
   const response = credential.response as AuthenticatorAssertionResponse
   return {
     id: credential.id,


### PR DESCRIPTION
Since the native parsing APIs are really new, there's a risk of inconsistency in their outputs. For now, use the manually-managed data and ignore whether the native APIs exist.

This has the nice side effect of a slightly slimmer bundle, but that's secondary to the actual goal here.

Fixes #8.

Follow-up: track the support of the native APIs and continue their use if appropriate - #17.