### PR TITLE
Rework and strengthen error handling

### DIFF
--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -16,8 +16,6 @@ import {
 /**
  * API formats
  */
-// success:true, token: string
-// success:false, error: info?
 type Result<T, E> =
   | { ok: true, data: T }
   | { ok: false, error: E, more?: unknown }
@@ -30,7 +28,6 @@ type WebAuthnError =
   | 'canceled_by_user'
   | 'invalid_domain'
   | 'browser_bug?'
-  // Other = 'other',
   | 'unexpected'
 
 export type AuthResponse = Result<{ token: string }, WebAuthnError>
@@ -53,7 +50,6 @@ class SDK {
   constructor(publicKey: string, host: string = 'https://api.webauthn.biz') {
     this.apiKey = publicKey
     this.host = host
-    this.host = 'http://do-not-resolve'
   }
 
   get isWebAuthnAvailable() {


### PR DESCRIPTION
This is as comprehensive as I can be for known error handling and conversion:

Network scenarios:
- Network can't connect
- Network timeout
- Got 4xx
- Got 5xx
- Succeeded

WebAuthn scenarios:
- Invalid `rpId` (user never sees UI)
- Timeout
- User cancels voluntarily
- User cancels involuntarily (e.g. no set of compatible credentials)
- Precautionary "WebAuthn API gave back weird data"

I haven't managed to get anything to leak, or even hit some of the safety-net cases. So anything else will be considered a future bugfix.

Fixes #2 