### PR TITLE
Make user info optional during registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapauth/sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "SnapAuth JS/TS SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Due to upstream API changes, both the `id` and `handle` fields are now optional, making registration even easier.