### PR TITLE
Register upgrades

### DIFF
--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -147,7 +147,7 @@ class SDK {
     if (!window.PublicKeyCredential || !window.PublicKeyCredential.getClientCapabilities) {
       return
     }
-    const capabilities = await PublicKeyCredential.getClientCapabilities()
+    const capabilities = await window.PublicKeyCredential.getClientCapabilities()
     if (!capabilities.conditionalCreate) {
       return
     }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -152,14 +152,14 @@ class SDK {
       return
     }
 
-    // TOOD: try/catch
+    // TODO: try/catch
     const res = await this.api('/registration/createOptions', {}) as Result<CredentialCreationOptionsJSON, WebAuthnError>
     if (!res.ok) {
       // No-op
       return
     }
     const options = parseCreateOptions(user, res.data)
-    options.publicKey.mediation = 'conditional'
+    options.mediation = 'conditional'
     const credential = await navigator.credentials.create(options)
     this.mustBePublicKeyCredential(credential)
     const json = registrationResponseToJSON(credential)

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -159,7 +159,9 @@ class SDK {
       // No-op
       return
     }
+    const signal = this.cancelExistingRequests()
     const options = parseCreateOptions(user, res.data)
+    options.signal = signal
     options.mediation = 'conditional'
     const credential = await navigator.credentials.create(options)
     this.mustBePublicKeyCredential(credential)

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -153,6 +153,7 @@ class SDK {
     }
 
     // TODO: try/catch
+    // TODO: BE upgrade:true param, have it serve `mediation:conditional`
     const res = await this.api('/registration/createOptions', {}) as Result<CredentialCreationOptionsJSON, WebAuthnError>
     if (!res.ok) {
       // No-op

--- a/src/fromJSON.ts
+++ b/src/fromJSON.ts
@@ -19,6 +19,7 @@ export const parseRequestOptions = (json: CredentialRequestOptionsJSON): Credent
 }
 
 export const parseCreateOptions = (user: UserRegistrationInfo, json: CredentialCreationOptionsJSON): CredentialCreationOptions => {
+  // TODO: mediation (see handleUpgrade)
   // Locally merge in user.name and displayName - they are never sent out and
   // not part of the server response.
   json.publicKey.user = {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,9 +1,23 @@
-interface PublicKeyCredentialStaticMethods {
+interface ClientCapabilities {
+  passkeyPlatformAuthenticator: boolean
+  conditionalMediation: boolean
+  conditionalCreate: boolean
+  userVerifyingPlatformAuthenticator: boolean
+  hybridTransport: boolean
+}
+
+interface PublicKeyCredentialConstructor {
+  // New (to-be-standardized?) API, currently Safari only
+  getClientCapabilities?: () => Promise<ClientCapabilities>
+  // Same, currently FF only
   // FIXME: wrong, this is json=>native (pk only?)
   parseCreationOptionsFromJSON?: (data: PublicKeyCredentialCreationOptionsJSON) => PublicKeyCredentialCreationOptions
   parseRequestOptionsFromJSON?: (data: PublicKeyCredentialRequestOptionsJSON) => PublicKeyCredentialRequestOptions
 }
-declare var PublicKeyCredential: PublicKeyCredentialStaticMethods
+// interface Window {
+//   PublicKeyCredential?: PublicKeyCredentialStaticMethods
+// }
+// declare var PublicKeyCredential: PublicKeyCredentialStaticMethods
 
 declare global {
 
@@ -44,6 +58,10 @@ declare global {
   interface PublicKeyCredential {
     toJSON?: () => PublicKeyCredentialJSON
   }
+  interface Window {
+    PublicKeyCredential?: PublicKeyCredentialConstructor
+  }
+  var PublicKeyCredential: PublicKeyCredentialConstructor
   // Same for request extensions
   interface PublicKeyCredentialRequestOptions {
     hints?: PublicKeyCredentialHints[],


### PR DESCRIPTION
Start to add SDK support for automatic passkey upgrades via conditional registration.

Needs some BE support on the registration API to return the new mediation field, but this ought to be close enough to start testing

TODO:
- [ ] Error handling
- [ ] Backend support & corresponding FE tweak
- [ ] Refactor to reduce duplicated logic in primary/modal registration process

Related but probably out of scope for this change:
- Revisit parameter names (change user.name to user.username?)
- Revisit method call names
- Continue to refine types