### PR TITLE
Add wrappers for availability APIs

### DIFF
--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -150,17 +150,9 @@ class SDK {
   }
 
   async handleAutofill(callback: (arg0: AuthResponse) => void) {
-    if (!this.isWebAuthnAvailable) {
+    if (!(await this.isConditionalMediationAvailable())) {
       return false
     }
-    if (!PublicKeyCredential.isConditionalMediationAvailable) {
-      return false
-    }
-    const isCMA = await PublicKeyCredential.isConditionalMediationAvailable()
-    if (!isCMA) {
-      return false
-    }
-
     // TODO: warn if no <input autocomplete="webauthn"> is found?
 
     // Autofill API is available. Make the calls and set it up.

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -68,7 +68,6 @@ class SDK {
     if (!window.PublicKeyCredential) {
       return false
     }
-    // Modern/upcoming API
     if (window.PublicKeyCredential.getClientCapabilities) {
       const cc = await window.PublicKeyCredential.getClientCapabilities()
       // Cast unexpected undefines to false
@@ -83,15 +82,17 @@ class SDK {
     }
     // Modern/upcoming API
     if (window.PublicKeyCredential.getClientCapabilities) {
-      // TODO: spec says `conditionalGet`; Safari (only browser so far with
-      // this API at all) has `conditionalMediation`
+      // Note: the spec says `conditionalGet`; Safari (only browser as of
+      // writing that has any support for this API) incorrectly sends
+      // `conditionalMediation`. Since this can fall back, look only at the
+      // correct name.
       // https://bugs.webkit.org/show_bug.cgi?id=275765
       const cc = await window.PublicKeyCredential.getClientCapabilities()
       if (cc.conditionalGet !== undefined) {
         return cc.conditionalGet
       }
     }
-    // More common (legacy?) API
+    // More commonly availalble (but presumed legacy) API
     if (window.PublicKeyCredential.isConditionalMediationAvailable) {
       return await window.PublicKeyCredential.isConditionalMediationAvailable()
     }

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -77,8 +77,7 @@ class SDK {
     return false
   }
 
-  // isConditionalGetAvailable?
-  async isConditionalMediationAvailable(): Promise<boolean> {
+  async isConditionalGetAvailable(): Promise<boolean> {
     if (!window.PublicKeyCredential) {
       return false
     }
@@ -92,6 +91,7 @@ class SDK {
         return cc.conditionalGet
       }
     }
+    // More common (legacy?) API
     if (window.PublicKeyCredential.isConditionalMediationAvailable) {
       return await window.PublicKeyCredential.isConditionalMediationAvailable()
     }
@@ -150,7 +150,7 @@ class SDK {
   }
 
   async handleAutofill(callback: (arg0: AuthResponse) => void) {
-    if (!(await this.isConditionalMediationAvailable())) {
+    if (!(await this.isConditionalGetAvailable())) {
       return false
     }
     // TODO: warn if no <input autocomplete="webauthn"> is found?

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -265,14 +265,4 @@ const formatError = <T>(error: WebAuthnError, obj: Error): Result<T, WebAuthnErr
   }
 })
 
-// type DictOf<T> = {[key: string]: T}
-type JsonEncodable =
-  | string
-  | number
-  | boolean
-  | null
-  | undefined
-  | { [key: string]: JsonEncodable }
-  | JsonEncodable[]
-
 export default SDK

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -64,6 +64,40 @@ class SDK {
     return !!window.PublicKeyCredential
   }
 
+  async isConditionalCreateAvailable(): Promise<boolean> {
+    if (!window.PublicKeyCredential) {
+      return false
+    }
+    // Modern/upcoming API
+    if (window.PublicKeyCredential.getClientCapabilities) {
+      const cc = await window.PublicKeyCredential.getClientCapabilities()
+      // Cast unexpected undefines to false
+      return cc.conditionalCreate === true
+    }
+    return false
+  }
+
+  // isConditionalGetAvailable?
+  async isConditionalMediationAvailable(): Promise<boolean> {
+    if (!window.PublicKeyCredential) {
+      return false
+    }
+    // Modern/upcoming API
+    if (window.PublicKeyCredential.getClientCapabilities) {
+      // TODO: spec says `conditionalGet`; Safari (only browser so far with
+      // this API at all) has `conditionalMediation`
+      // https://bugs.webkit.org/show_bug.cgi?id=275765
+      const cc = await window.PublicKeyCredential.getClientCapabilities()
+      if (cc.conditionalGet !== undefined) {
+        return cc.conditionalGet
+      }
+    }
+    if (window.PublicKeyCredential.isConditionalMediationAvailable) {
+      return await window.PublicKeyCredential.isConditionalMediationAvailable()
+    }
+    return false
+  }
+
   async startAuth(user: UserAuthenticationInfo): Promise<AuthResponse> {
     if (!this.isWebAuthnAvailable) {
       return { ok: false, error: 'webauthn_unavailable' }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,6 +6,14 @@ interface PublicKeyCredentialStaticMethods {
 declare var PublicKeyCredential: PublicKeyCredentialStaticMethods
 
 declare global {
+  type JsonEncodable =
+    | string
+    | number
+    | boolean
+    | null
+    | undefined
+    | { [key: string]: JsonEncodable }
+    | JsonEncodable[]
 
   interface PublicKeyCredentialCreationOptionsJSON {
     rp: PublicKeyCredentialRpEntity

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,14 @@
+type ClientCapability =
+  | "conditionalCreate"
+  | "conditionalGet"
+  | "hybridTransport"
+  | "passkeyPlatformAuthenticator"
+  | "userVerifyingPlatformAuthenticator"
+
+type PublicKeyCredentialClientCapabilities = Record<ClientCapability, boolean>
 interface PublicKeyCredentialStaticMethods {
   // FIXME: wrong, this is json=>native (pk only?)
+  getClientCapabilities?: () => Promise<PublicKeyCredentialClientCapabilities>
   parseCreationOptionsFromJSON?: (data: PublicKeyCredentialCreationOptionsJSON) => PublicKeyCredentialCreationOptions
   parseRequestOptionsFromJSON?: (data: PublicKeyCredentialRequestOptionsJSON) => PublicKeyCredentialRequestOptions
 }
@@ -14,6 +23,11 @@ declare global {
     | undefined
     | { [key: string]: JsonEncodable }
     | JsonEncodable[]
+
+  // Tell typescipt about upcoming PKC methods
+  interface Window {
+    PublicKeyCredential?: PublicKeyCredentialStaticMethods
+  }
 
   interface PublicKeyCredentialCreationOptionsJSON {
     rp: PublicKeyCredentialRpEntity


### PR DESCRIPTION
Adds two new public SDK methods: `isConditionalGetAvailable(): Promise<boolean>` and `isConditionalCreateAvailable(): Promise<boolean>`. As the names suggest, they provide information about availability of the `mediation: conditional` paths for `get()` (passkey autofill) and `create()` (automatic passkey creation on sign in),

It is NOT necessary for clients to call these prior to using the other SnapAuth Client APIs - but they're available to have the option of modifying the UI based on client capabilities (as well as for internal use).