### PR TITLE
Make JsonEncodable global, and add the new getClientCapabilities API

### DIFF
--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -265,14 +265,4 @@ const formatError = <T>(error: WebAuthnError, obj: Error): Result<T, WebAuthnErr
   }
 })
 
-// type DictOf<T> = {[key: string]: T}
-type JsonEncodable =
-  | string
-  | number
-  | boolean
-  | null
-  | undefined
-  | { [key: string]: JsonEncodable }
-  | JsonEncodable[]
-
 export default SDK

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,33 @@
+type ClientCapability =
+  | "conditionalCreate"
+  | "conditionalGet"
+  | "hybridTransport"
+  | "passkeyPlatformAuthenticator"
+  | "userVerifyingPlatformAuthenticator"
+
+type PublicKeyCredentialClientCapabilities = Record<ClientCapability, boolean>
 interface PublicKeyCredentialStaticMethods {
   // FIXME: wrong, this is json=>native (pk only?)
+  getClientCapabilities?: () => Promise<PublicKeyCredentialClientCapabilities>
   parseCreationOptionsFromJSON?: (data: PublicKeyCredentialCreationOptionsJSON) => PublicKeyCredentialCreationOptions
   parseRequestOptionsFromJSON?: (data: PublicKeyCredentialRequestOptionsJSON) => PublicKeyCredentialRequestOptions
 }
 declare var PublicKeyCredential: PublicKeyCredentialStaticMethods
 
 declare global {
+  type JsonEncodable =
+    | string
+    | number
+    | boolean
+    | null
+    | undefined
+    | { [key: string]: JsonEncodable }
+    | JsonEncodable[]
+
+  // Tell typescipt about upcoming PKC methods
+  interface Window {
+    PublicKeyCredential?: PublicKeyCredentialStaticMethods
+  }
 
   interface PublicKeyCredentialCreationOptionsJSON {
     rp: PublicKeyCredentialRpEntity


### PR DESCRIPTION
This adds type definitions for [Client Capabilities](https://w3c.github.io/webauthn/#sctn-getClientCapabilities), which is (or soon will be) a replacement for the several other promise-based APIs.

Note that other capabilities are currently in an even earlier-draft state as of writing (still in W3 PRs or explainers) and have been intentionally omitted. The above is a living document, so future references may be out of date.