### PR TITLE
Hook beforeunload to cancel existing requests

### DIFF
--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -59,6 +59,7 @@ class SDK {
   constructor(publicKey: string, host: string = 'https://api.snapauth.app') {
     this.apiKey = publicKey
     this.host = host
+    window.addEventListener('beforeunload', this.cancelExistingRequests)
   }
 
   get isWebAuthnAvailable() {


### PR DESCRIPTION
We've been seeing passkeys on desktop Safari getting progressively less reliable, as noted in [this bug](https://bugs.webkit.org/show_bug.cgi?id=273712). My hunch is that there's some sort of browser-wide state getting thrown off if requests (in practice, only conditional) hang around.

To be clear, I'm not sure if this will actually work. I haven't witnessed it causing any issues, and it seemed to minorly improve the situation (but the system in question is completely opaque to me, so it's just as likely coincidental) - after testing locally, Safari seemed to be not _completely_ stuck after a couple cycles through. Other than a handful of additional bytes, I don't see much of a downside here.