### PR TITLE
Make parameter names in core APIs more consistent

### DIFF
--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -40,12 +40,13 @@ export type RegisterResponse = Result<{ token: string }, WebAuthnError>
 
 type UserIdOrHandle =
   | { id: string }
-  | { handle: string }
+  | { username: string }
 type OptionalUserIdOrHandle = UserIdOrHandle | undefined
 
 export type UserAuthenticationInfo = UserIdOrHandle
 export type UserRegistrationInfo = {
-  name: string
+  // name: string
+  username: string
   displayName?: string
   id?: string
   handle?: string

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -38,12 +38,12 @@ type WebAuthnError =
 export type AuthResponse = Result<{ token: string }, WebAuthnError>
 export type RegisterResponse = Result<{ token: string }, WebAuthnError>
 
-type UserIdOrHandle =
+type UserIdOrUsername =
   | { id: string }
   | { username: string }
-type OptionalUserIdOrHandle = UserIdOrHandle | undefined
+type OptionalUserIdOrUsername = UserIdOrUsername | undefined
 
-export type UserAuthenticationInfo = UserIdOrHandle
+export type UserAuthenticationInfo = UserIdOrUsername
 export type UserRegistrationInfo = {
   // name: string
   username: string
@@ -189,7 +189,7 @@ class SDK {
     }
   }
 
-  private async doAuth(user: UserIdOrHandle|undefined): Promise<AuthResponse> {
+  private async doAuth(user: UserIdOrUsername|undefined): Promise<AuthResponse> {
     // Get the remotely-built WebAuthn options
     const res = await this.api('/assertion/options', { user }) as Result<CredentialRequestOptionsJSON, WebAuthnError>
     if (!res.ok) {
@@ -311,7 +311,7 @@ class SDK {
    * Privacy enhancement: removes data from network request not needed by
    * backend to complete registration
    */
-  private filterRegistrationData(user: UserRegistrationInfo): UserIdOrHandle|undefined {
+  private filterRegistrationData(user: UserRegistrationInfo): UserIdOrUsername|undefined {
     // If user info provided, send only the id or handle. Do NOT send name or
     // displayName.
     if (user.id || user.handle) {

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -314,11 +314,11 @@ class SDK {
   private filterRegistrationData(user: UserRegistrationInfo): UserIdOrUsername|undefined {
     // If user info provided, send only the id or handle. Do NOT send name or
     // displayName.
-    if (user.id || user.handle) {
+    if (user.id || user.username) {
       return {
         id: user.id,
-          // @ts-ignore figure this type hack out later
-        handle: user.handle,
+        // @ts-ignore figure this type hack out later
+        username: user.username,
       }
     }
   }

--- a/src/fromJSON.ts
+++ b/src/fromJSON.ts
@@ -16,13 +16,20 @@ export const parseRequestOptions = (json: CredentialRequestOptionsJSON): Credent
   return getOptions
 }
 
-export const parseCreateOptions = (user: UserRegistrationInfo, json: CredentialCreationOptionsJSON): CredentialCreationOptions => {
-  // Locally merge in user.name and displayName - they are never sent out (see
-  // filterRegistrationData) and thus are not part of the server response.
+type CombinedRegistrationFormat =
+  | UserRegistrationInfo
+  | { name: string, displayName?: string }
+
+export const parseCreateOptions = (user: CombinedRegistrationFormat, json: CredentialCreationOptionsJSON): CredentialCreationOptions => {
+  // Combine the server response (w/ user.id) and the client data into the
+  // webAuthn structure, which requires `id`, `name`, and `displayName`.
+  // What WebAuthn calls `name` we call `username` to enhance usage clarity.
+  //
+  // Pre-1.0, continue to support `name` as well.
   json.publicKey.user = {
     ...json.publicKey.user,
-    name: user.username ?? user.handle,
-    displayName: user.displayName ?? user.username ?? user.handle,
+    name: user.username ?? user.name,
+    displayName: user.displayName ?? user.username ?? user.name,
   }
 
   let createOptions: CredentialCreationOptions = {}

--- a/src/fromJSON.ts
+++ b/src/fromJSON.ts
@@ -21,8 +21,8 @@ export const parseCreateOptions = (user: UserRegistrationInfo, json: CredentialC
   // filterRegistrationData) and thus are not part of the server response.
   json.publicKey.user = {
     ...json.publicKey.user,
-    name: user.name,
-    displayName: user.displayName ?? user.name,
+    name: user.username,
+    displayName: user.displayName ?? user.username,
   }
 
   let createOptions: CredentialCreationOptions = {}

--- a/src/fromJSON.ts
+++ b/src/fromJSON.ts
@@ -21,8 +21,8 @@ export const parseCreateOptions = (user: UserRegistrationInfo, json: CredentialC
   // filterRegistrationData) and thus are not part of the server response.
   json.publicKey.user = {
     ...json.publicKey.user,
-    name: user.username,
-    displayName: user.displayName ?? user.username,
+    name: user.username ?? user.handle,
+    displayName: user.displayName ?? user.username ?? user.handle,
   }
 
   let createOptions: CredentialCreationOptions = {}

--- a/src/fromJSON.ts
+++ b/src/fromJSON.ts
@@ -28,7 +28,9 @@ export const parseCreateOptions = (user: CombinedRegistrationFormat, json: Crede
   // Pre-1.0, continue to support `name` as well.
   json.publicKey.user = {
     ...json.publicKey.user,
+    // @ts-ignore It's incorrectly inferring username|name
     name: user.username ?? user.name,
+    // @ts-ignore same
     displayName: user.displayName ?? user.username ?? user.name,
   }
 

--- a/src/fromJSON.ts
+++ b/src/fromJSON.ts
@@ -26,12 +26,12 @@ export const parseCreateOptions = (user: CombinedRegistrationFormat, json: Crede
   // What WebAuthn calls `name` we call `username` to enhance usage clarity.
   //
   // Pre-1.0, continue to support `name` as well.
+  // @ts-ignore It's incorrectly inferring username|name
+  const name = user.username ?? user.name
   json.publicKey.user = {
     ...json.publicKey.user,
-    // @ts-ignore It's incorrectly inferring username|name
-    name: user.username ?? user.name,
-    // @ts-ignore same
-    displayName: user.displayName ?? user.username ?? user.name,
+    name,
+    displayName: user.displayName ?? name,
   }
 
   let createOptions: CredentialCreationOptions = {}

--- a/src/fromJSON.ts
+++ b/src/fromJSON.ts
@@ -18,7 +18,7 @@ export const parseRequestOptions = (json: CredentialRequestOptionsJSON): Credent
 
 type CombinedRegistrationFormat =
   | UserRegistrationInfo
-  | { name: string, displayName?: string }
+  | { name: string, displayName?: string } // Legacy registration: name instead of username
 
 export const parseCreateOptions = (user: CombinedRegistrationFormat, json: CredentialCreationOptionsJSON): CredentialCreationOptions => {
   // Combine the server response (w/ user.id) and the client data into the


### PR DESCRIPTION
This replaces the `name` parameter during both registration (required) and authentication (optional) with `username`. This better reflects what the parameter actually represents, and helps disambiguate it from a display name.

In doing so, I've adjusted the calls to the backend during registration to omit this data completely, since only the `upgrade` parameter is used in practice. This keeps data filtering simpler.

Prior to a 1.0 tag, this retains support for the older `name` parameter at runtime only. TypeScript users will get an immediate type error but nothing will break if they ignore it; plain JS users will get no such warning and things will continue to work. I'll open follow-up tasks to remove it completely.

Fixes #48